### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ The following packages are available on [nuget.org](https://nuget.org) that prov
     var configuration = new SetupConfiguration();
     ```
 
+>`The Microsoft.VisualStudio.Setup.Configuration.Interop` package cannot be added as a `PackageReference`, it must be declared in a `packages.config` file for the `SetupConfiguration` class to be correctly exposed.
+
 Updates
 -------
 


### PR DESCRIPTION
I found that if I allowed the `Microsoft.VisualStudio.Setup.Configuration.Interop` package to be added as a `PackageReference` that `SetupConfiguration` was not found by the C# compiler.

Removing the package reference, and adding the package in a `packages.config` file resulted in the `SetupConfiguration` class being found by the compiler